### PR TITLE
Add bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,6 +2,6 @@
 current_version = 2.8.1
 commit = True
 tag = True
-tag_name = v{new_version}
+tag_name = {new_version}
 
 [bumpversion:file:setup.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.8.1
+current_version = 0.1.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,7 @@
+[bumpversion]
+current_version = 2.8.1
+commit = True
+tag = True
+tag_name = v{new_version}
+
+[bumpversion:file:setup.py]

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ class UploadCommand(Command):
 # Where the magic happens:
 setup(
     name=NAME,
-    version=about['__version__'],
+    version='0.1.0',
     description=DESCRIPTION,
     long_description=long_description,
     author=AUTHOR,


### PR DESCRIPTION
These small changes makes it possible to use bumpversion to keep track of versioning. Info on how to use it in the development repo [here](https://github.com/Clinical-Genomics/development/blob/master/development/bumpversion.md).